### PR TITLE
Add evaluation for migrating backend to Node.js

### DIFF
--- a/docs/migration_evaluation.md
+++ b/docs/migration_evaluation.md
@@ -1,0 +1,39 @@
+# .NET8 SqlSugar 后端迁移至 Node.js（Express + Knex）评估报告
+
+## 1. 项目现状概述
+- 当前后端以 `VOL.WebApi` 为主入口，Startup 中集成了 JWT 鉴权、Swagger、Quartz 调度、SqlSugar 数据访问以及 Autofac 依赖注入等组件，形成了一个围绕 ASP.NET Core 管道的完整基础设施。【F:vol.api.sqlsugar/VOL.WebApi/Startup.cs†L1-L200】
+- 业务服务遵循统一的 `ServiceBase<T, TRepository>` 抽象，内建缓存、多租户过滤、分页排序等通用能力，配合泛型仓储模式执行 SqlSugar 查询。【F:vol.api.sqlsugar/VOL.Core/BaseProvider/ServiceBase.cs†L1-L188】
+- 代码生成相关逻辑集中在 `VOL.Builder` 模块，通过服务层直接操作 `Sys_TableInfo` 等实体，读取数据库结构并生成 API、仓储、前端页面及配置文件。【F:vol.api.sqlsugar/VOL.Builder/Services/Core/Partial/Sys_TableInfoService.cs†L270-L552】【F:vol.api.sqlsugar/VOL.Builder/Services/Core/Partial/Sys_TableInfoService.cs†L661-L1054】
+- 模板资源位于 `VOL.WebApi/Template` 目录，涵盖控制器、仓储、服务、Vue 页面及应用端配置等多种模板文件，是代码生成器的核心资产。【c1e36b†L1-L2】
+
+## 2. 代码生成器关键能力
+- 根据数据库表结构生成实体模型，自动判断目标数据库类型（SqlServer/MySQL/PgSQL）并映射字段类型、长度与约束，确保生成代码与实际表结构一致。【F:vol.api.sqlsugar/VOL.Builder/Services/Core/Partial/Sys_TableInfoService.cs†L270-L439】【F:vol.api.sqlsugar/VOL.Builder/Services/Core/Partial/Sys_TableInfoService.cs†L1071-L1180】
+- 自动创建仓储、服务、控制器及对应的 Partial 拓展文件，按命名空间和目录结构写入文件系统，同时生成 Vue 前端页面、路由和配置，支持主从表、App、Vite 等多种场景。【F:vol.api.sqlsugar/VOL.Builder/Services/Core/Partial/Sys_TableInfoService.cs†L441-L552】【F:vol.api.sqlsugar/VOL.Builder/Services/Core/Partial/Sys_TableInfoService.cs†L661-L1054】
+- 支持同步表结构、维护配置树以及权限检查，提供保存配置、删除节点等管理功能，保证生成器配置与数据库保持同步。【F:vol.api.sqlsugar/VOL.Builder/Services/Core/Partial/Sys_TableInfoService.cs†L374-L438】【F:vol.api.sqlsugar/VOL.Builder/Services/Core/Partial/Sys_TableInfoService.cs†L1439-L1564】
+
+## 3. 迁移目标与挑战
+### 3.1 功能目标
+- 将现有 REST API 与业务逻辑迁移至 Node.js（Express + Knex），保持认证、权限、调度、文件上传等能力。
+- 重构代码生成器，使其在 Node 环境下继续支持实体、仓储、服务、控制器与 Vue 页面模板输出，并维持现有配置管理体验。
+
+### 3.2 关键难点
+1. **基础设施替换成本高**：.NET 端依赖 Autofac、SqlSugar、Quartz、JWT 中间件等，需要在 Node.js 中寻找等价方案（如 `awilix`/手写容器、Knex QueryBuilder、agenda/node-cron、jsonwebtoken 等），并重新实现跨模块的统一封装。
+2. **代码生成器复杂度**：生成器不仅生成 API，还会根据多种前端模式生成 Vue/App/Vite 模板、路由及配置，涉及大量文件操作与模板替换逻辑，迁移时需重写模板渲染与目录管理工具链，并确保与现有前端工程约定保持一致。【F:vol.api.sqlsugar/VOL.Builder/Services/Core/Partial/Sys_TableInfoService.cs†L661-L1054】
+3. **数据库元数据读取**：目前依赖 SqlSugar 的 SQL 模板读取不同数据库系统的元数据；迁移到 Knex 后需针对多种数据库重新实现元数据抽象，并处理与 SqlSugar 不同的类型映射策略。【F:vol.api.sqlsugar/VOL.Builder/Services/Core/Partial/Sys_TableInfoService.cs†L270-L439】【F:vol.api.sqlsugar/VOL.Builder/Services/Core/Partial/Sys_TableInfoService.cs†L1071-L1180】
+4. **权限与多租户**：`ServiceBase` 中内置了多租户、缓存、操作过滤、分页排序等横切逻辑，迁移时需要在 Node.js 中重构等价的服务基类与中间件管线，确保行为一致。【F:vol.api.sqlsugar/VOL.Core/BaseProvider/ServiceBase.cs†L1-L188】
+5. **部署与运维差异**：.NET 方案可能依赖 Windows/IIS 或 Kestrel 配置，迁移后需重新规划 Node.js 的部署、日志、监控方案，并处理与现有前端、代码生成器交互方式的变化。
+
+## 4. 迁移实施建议
+1. **分阶段重构**：先抽象现有系统的领域模型、服务接口与生成器流程，划分可独立迁移的模块，逐步在 Node.js 中复现，避免一次性切换导致的风险。
+2. **模板与配置先行**：优先提取 `Template` 目录下的模板文件，定义统一的 Node.js 渲染引擎（如 Handlebars/EJS），确保新生成器输出与旧版一致。【c1e36b†L1-L2】
+3. **Knex 元数据封装**：为不同数据库实现独立的元数据读取模块，复用现有 SQL 模板的业务规则，并建立类型映射表，以保证实体/迁移代码准确。
+4. **服务基类设计**：在 Express + Knex 环境下设计新的 Service/Repository 基类，重建缓存、多租户、查询构建等通用能力，逐步迁移具体业务模块。
+5. **并行验证**：在迁移初期保持 .NET 与 Node 两套服务并行，利用自动化测试验证接口一致性，逐步替换生产流量。
+6. **生成器联动测试**：为生成器输出的各类模板设计用例，验证 Node 版本能正确生成 Vue 页面、后端代码，并可在新架构下运行。
+
+## 5. 难度评估
+- **总体难度：高**。需要同时迁移成熟的后端框架与复杂的代码生成器，涉及基础设施替换、模板体系重写以及多数据库元数据适配，预计工作量较大，风险集中在生成器与通用框架层。
+- **时间预估**：若以 3~4 人的全栈小组投入，完成第一版 MVP（基础 API + 生成器核心功能）可能需要 3~4 个月，后续优化和边缘功能迁移仍需额外迭代。
+
+## 6. 结论
+建议采用渐进式迁移策略：先沉淀现有生成器与服务层规则，再逐步在 Node.js 中重构关键基础设施。务必为代码生成器设立独立的模板渲染与元数据模块，并尽早建立自动化验证，以降低迁移过程中的回归风险。


### PR DESCRIPTION
## Summary
- add a Chinese assessment document in docs/ explaining the effort to migrate the SqlSugar backend and code generator to Node.js (Express + Knex)

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95639e43483249944b0a90163f4b9